### PR TITLE
run.R added

### DIFF
--- a/run.R
+++ b/run.R
@@ -1,0 +1,2 @@
+library(shiny)
+runApp('R')


### PR DESCRIPTION
Easier to start the shiny app from Rstudio (instead of using the docker): execute install.R and then run.R (or click on the "Run App" button in Rstudio).